### PR TITLE
Added multi-map exporter feature for kachaka fleet demo

### DIFF
--- a/python/demos/grpc_samples/multi_map_exporter.py
+++ b/python/demos/grpc_samples/multi_map_exporter.py
@@ -1,0 +1,289 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Multi-Map Exporter a python script for Kachaka Fleet Manager configuration on edge PC.
+
+Author: Jimmy Majumder
+Date: 2025-02-18
+Copyright: QibiTech Inc.
+
+Description:
+This script exports maps from multiple Kachaka robots to a centralized edge PC. It facilitates fleet management 
+by automating map data extraction (PNG, YAML metadata, binary cursor files) 
+and ensuring structured storage.
+
+Functionality:
+- Establishes gRPC connections with multiple Kachaka robots.
+- Extracts and saves map data (PNG, YAML metadata, binary cursor files).
+- Transfers map files securely to an edge PC using SCP.
+- Ensures structured storage of maps per robot to facilitate fleet operations.
+- Logs execution details to a log file for debugging and audit purposes.
+
+System Requirements:
+- sshpass: Required for non-interactive SCP file transfers.  Consider SSH key-based 
+  authentication for enhanced security in production environments.
+- gRPC:  Ensure the gRPC service is running and accessible on each Kachaka robot.
+- SSH access: The edge PC must permit SSH connections from the executing system.
+
+Security Considerations:
+- The script prompts for an SSH password at runtime; it is not stored in plaintext.
+- It is recommended to use SSH key-based authentication for production deployments.
+- Ensure that the edge PC is secure and has proper access controls in place.
+
+Usage:
+Execute the script: python3 multi_map_exporter.py
+
+***Note:
+Before running the script, please ensure you have read the following documentation:
+README - Setup & Procedure: 
+https://bitbucket.org/qibitech/kachaka-api/src/b2bfce371dcf0a36132c082d348521c0085e94ba/python/demos/README_SMART_SPEAKER.md?at=feature%2Fmulti_map_setup_fleet_manager
+
+Prerequisites:
+1. git clone git@bitbucket.org:qibitech/kachaka-api.git # clone the repository
+2. python3 -m venv venv # do this if you want to create a virtual environment
+3. source venv/bin/activate # do this if you created a virtual environment
+4. cd kachaka-api/python/demos # go to the directory where the script is located
+5. pip install -r requirements.txt
+6. cd grpc_samples
+7. python3 -m grpc_tools.protoc -I../../../protos --python_out=. --pyi_out=. --grpc_python_out=. ../../../protos/kachaka-api.proto # make sure where the proto file is located
+8. python3 multi_map_exporter.py # run the script
+"""
+
+import sys
+import grpc
+import kachaka_api_pb2
+from kachaka_api_pb2_grpc import KachakaApiStub
+import yaml
+import struct
+import threading
+import re
+import subprocess
+import os
+import getpass
+import logging
+from datetime import datetime
+
+# Configuration
+GRPC_CHANNEL_ADDRESSES = [
+    "192.168.2.77:26400",  # Kachaka_Sales01 (Replace with actual IP:port)
+    # "192.168.2.78:26400",  # Kachaka_11 (Replace with actual IP:port)
+    # "192.168.2.79:26400",  # Kachaka_12 (Replace with actual IP:port)
+]
+
+# EDGE_PC_DESCRIPTION:
+#     "The Edge PC is a centralized PC"
+#     "In QibiTech, the Edge PC ensures synchronized control and fleet management of different types of robots, "
+#     "It functions as a bridge to the HATS system, providing seamless communication between fleet manager, kachaka robot and HATS UI. "
+#     "It facilitating real-time monitoring, decision-making, data-driven feedback monitoring."
+
+EDGE_PC_IP = "192.168.2.183" # default IP, change as needed
+EDGE_PC_USERNAME = "qtmember" # default username , change as needed
+EDGE_PC_MAP_DIR = "/usr/local/share/hats_sdk/map/" # default directory, change as needed
+
+# Logging Setup
+LOG_DIR = "logs"
+os.makedirs(LOG_DIR, exist_ok=True)
+LOG_FILE = os.path.join(LOG_DIR, f"kachaka_map_transfer_{datetime.now().strftime('%Y%m%d_%H%M%S')}.log")
+logging.basicConfig(filename=LOG_FILE, level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+
+def _log_message(level, message):
+    """
+    Logs messages to both console and log file.
+
+    Args:
+        level (int): Logging level (e.g., logging.INFO, logging.ERROR).
+        message (str): The message to log.
+    """
+    print(message)  # Always print to console
+    logging.log(level, message)
+
+def log_info(message):
+    """Logs an informational message."""
+    _log_message(logging.INFO, message)
+
+def log_error(message):
+    """Logs an error message."""
+    _log_message(logging.ERROR, f"ERROR: {message}")  # Added ERROR prefix
+
+def check_ssh_connection(password):
+    """
+    Verifies SSH connectivity to the edge PC.
+
+    Args:
+        password (str): SSH password.
+
+    Returns:
+        bool: True if connection is successful, False otherwise.
+    """
+    try:
+        ssh_command = [
+            "sshpass", "-p", password, "ssh",
+            f"{EDGE_PC_USERNAME}@{EDGE_PC_IP}",
+            "echo 'SSH connection successful'"  # A simple command to test connectivity
+        ]
+        subprocess.run(ssh_command, check=True, capture_output=True, text=True)
+        log_info("SSH connection successful")
+        return True
+    except subprocess.CalledProcessError as e:
+        log_error(f"SSH connection failed: {e.stderr}")
+        return False
+
+def sanitize_filename(filename):
+    """
+    Sanitizes a filename by replacing invalid characters with underscores.
+
+    Args:
+        filename (str): The filename to sanitize.
+
+    Returns:
+        str: The sanitized filename.
+    """
+    return re.sub(r'[^\w\-_\.]', '_', filename)
+
+def create_remote_directory(robot_id, password):
+    """
+    Creates a directory on the edge PC for storing map data.
+
+    Args:
+        robot_id (str): The robot's serial number (used as directory name).
+        password (str): SSH password.
+    """
+    try:
+        ssh_command = [
+            "sshpass", "-p", password, "ssh",
+            f"{EDGE_PC_USERNAME}@{EDGE_PC_IP}",
+            f"mkdir -p {EDGE_PC_MAP_DIR}{robot_id}"
+        ]
+        subprocess.run(ssh_command, check=True, capture_output=True, text=True)
+        log_info(f"Successfully created directory {EDGE_PC_MAP_DIR}{robot_id} on edge PC")
+    except subprocess.CalledProcessError as e:
+        log_error(f"Error creating directory {EDGE_PC_MAP_DIR}{robot_id} on edge PC: {e.stderr}")
+        raise  # Re-raise exception to stop further processing if directory creation fails
+
+def transfer_files_scp(source_file, robot_id, destination, password):
+    """
+    Transfers files to the edge PC using SCP.
+
+    Args:
+        source_file (str): Path to the file to transfer.
+        robot_id (str): The robot's serial number.
+        destination (str): Destination directory on the edge PC.
+        password (str): SSH password.
+    """
+    try:
+        robot_dir = f"{destination}{robot_id}/"
+        scp_command = [
+            "sshpass", "-p", password, "scp",
+            source_file,
+            f"{EDGE_PC_USERNAME}@{EDGE_PC_IP}:{robot_dir}"
+        ]
+        subprocess.run(scp_command, check=True, capture_output=True, text=True)
+        log_info(f"Successfully transferred {source_file} to {robot_dir}")
+    except subprocess.CalledProcessError as e:
+        log_error(f"Error transferring {source_file} to {robot_dir}: {e.stderr}")
+        raise  # Re-raise exception to stop further processing if file transfer fails
+
+def get_map_data(grpc_channel_address, password):
+    """
+    Retrieves map data from a Kachaka robot via gRPC.
+
+    Args:
+        grpc_channel_address (str): The IP address and port of the Kachaka robot.
+        password (str): SSH password.
+    """
+    try:
+        stub = KachakaApiStub(grpc.insecure_channel(grpc_channel_address))
+
+        serial_number_response = stub.GetRobotSerialNumber(kachaka_api_pb2.GetRequest())
+        robot_serial_number = serial_number_response.serial_number
+        log_info(f"---------- serial number ({grpc_channel_address}): {robot_serial_number} ----------")
+
+        current_map_id_response = stub.GetCurrentMapId(kachaka_api_pb2.GetRequest())
+        map_id = current_map_id_response.id
+        log_info(f"---------- map id ({grpc_channel_address}): {map_id} ----------")
+
+        response = stub.GetRobotVersion(kachaka_api_pb2.GetRequest())
+        log_info(f"---------- robot version ({grpc_channel_address}) ----------")
+        log_info(str(response))
+
+        response = stub.GetPngMap(kachaka_api_pb2.GetRequest())
+        log_info(f"---------- Map ({grpc_channel_address}) ----------")
+        log_info(str(response))
+
+        map_name = sanitize_filename(response.map.name)
+        filename_prefix = f"{map_name}"
+        png_filename = f"{filename_prefix}.png"
+        yaml_filename = f"{filename_prefix}_metadata.yaml"
+        bin_filename = f"{filename_prefix}_metadata.bin"
+
+        # Create a directory for this robot locally
+        robot_dir = f"Kachaka_{robot_serial_number}"
+        os.makedirs(robot_dir, exist_ok=True)
+        log_info(f"Successfully created local directory: {robot_dir}")
+
+        # Save files locally
+        with open(os.path.join(robot_dir, png_filename), "wb") as binary_file:
+            binary_file.write(response.map.data)
+        log_info(f"Successfully saved {png_filename} locally.")
+
+        map_metadata = {
+            "name": response.map.name,
+            "resolution": response.map.resolution,
+            "width": response.map.width,
+            "height": response.map.height,
+            "origin": {
+                "x": response.map.origin.x,
+                "y": response.map.origin.y,
+                "theta": response.map.origin.theta,
+            },
+        }
+
+        log_info(f"Extracted Map Metadata ({grpc_channel_address}): {map_metadata}")
+
+        with open(os.path.join(robot_dir, yaml_filename), "w") as yaml_file:
+            yaml.dump(map_metadata, yaml_file, default_flow_style=False)
+        log_info(f"Successfully saved {yaml_filename} locally.")
+
+        cursor_value = response.metadata.cursor
+        with open(os.path.join(robot_dir, bin_filename), "wb") as binary_file:
+            binary_file.write(struct.pack("<q", cursor_value))
+        log_info(f"Successfully saved {bin_filename} locally.")
+
+        with open(os.path.join(robot_dir, bin_filename), "rb") as binary_file:
+            binary_data = binary_file.read(8)
+            cursor_value_read = struct.unpack("<q", binary_data)[0]
+            log_info(f"Read Cursor Value ({grpc_channel_address}): {cursor_value_read}")
+
+        # Create remote directory and transfer files
+        create_remote_directory(robot_dir, password)
+        transfer_files_scp(os.path.join(robot_dir, png_filename), robot_dir, EDGE_PC_MAP_DIR, password)
+        transfer_files_scp(os.path.join(robot_dir, yaml_filename), robot_dir, EDGE_PC_MAP_DIR, password)
+        transfer_files_scp(os.path.join(robot_dir, bin_filename), robot_dir, EDGE_PC_MAP_DIR, password)
+
+    except grpc.RpcError as e:
+        log_error(f"Error connecting to {grpc_channel_address}: {e}")
+    except Exception as e:
+        log_error(f"An unexpected error occurred: {e}")
+
+def main():
+    """Main function to orchestrate map data retrieval and transfer."""
+    # Prompt for password once at the beginning
+    password = getpass.getpass("Enter your SSH password: ")
+
+    if not check_ssh_connection(password):
+        log_error("Failed to establish SSH connection. Exiting.")
+        return
+
+    threads = []
+    for address in GRPC_CHANNEL_ADDRESSES:
+        thread = threading.Thread(target=get_map_data, args=(address, password))
+        threads.append(thread)
+        thread.start()
+
+    for thread in threads:
+        thread.join()
+
+    log_info("Map transfer process completed")
+
+if __name__ == "__main__":
+    main()

--- a/python/demos/grpc_samples/multi_map_exporter_kachaka_fleet.puml
+++ b/python/demos/grpc_samples/multi_map_exporter_kachaka_fleet.puml
@@ -1,0 +1,75 @@
+@startuml multi_map_exporter_kachaka_fleet
+actor User as U
+participant "Local PC\n(Fleet Manager)" as FM
+participant "Kachaka Robot\n(gRPC Server)" as KR
+participant "Edge PC\n(HAT SDK)" as EP
+database "robot_config.json" as ConfigDB
+
+skinparam {
+  FontName Arial
+  FontSize 12
+  ArrowColor #4A90E2
+  ActorBorderColor #4A90E2
+  ComponentBorderColor #4A90E2
+  DatabaseBorderColor #4A90E2
+  NoteBackgroundColor #FFFFCC
+  NoteBorderColor #DDBB77
+}
+
+== 1. Initialize Map Export ==
+U -> FM: Run multi_map_exporter.py\nin /ros2_ws/src/kachaka-api/python/demos/grpc_samples
+activate FM
+
+note right of FM
+  Includes robot IPs, map paths,
+  and Fleet Manager settings
+end note
+
+== 2. Discover Robots and Maps (gRPC) ==
+loop For each robot in config
+    FM -> KR: GetRobotSerialNumber (gRPC)
+    activate KR
+    KR --> FM: Return serial_number
+    deactivate KR
+
+    FM -> KR: GetCurrentMapId (gRPC)
+    activate KR
+    KR --> FM: Return map_id
+    deactivate KR
+
+    FM -> KR: GetPngMap (gRPC)
+    activate KR
+    KR --> FM: Return map data (PNG, metadata)
+    deactivate KR
+
+    FM -> FM: Sanitize map name
+    FM -> FM: Generate file names\n(map_name.png, map_name_metadata.yaml,\nmap_name_metadata.bin)
+    FM -> FM: Create robot-specific directory\n(Kachaka_<serial_number>)
+    FM -> FM: Save files in robot-specific directory
+end
+
+== 3. Transfer Maps to Edge PC (SCP) ==
+FM -> FM: Execute SCP command\n(using SSH keys)
+FM -> EP: Transfer robot-specific directories via SCP
+activate EP
+EP -> EP: Store files in\n/usr/local/share/hat_sdk/map/Kachaka_<serial_number>/
+EP --> FM: Confirm file transfer
+deactivate EP
+
+== 4. Ikkatsu Parameter Update (HATS UI Triggered) ==
+U -> FM: Trigger "ikkatsu" (batch) update in HATS UI
+FM -> FM: Send ikkatsu parameters\n(config_file_path, map info)
+note left of FM: data = {\n  'config_file_path': ..., \n  'map': {\n    'map_image_path': ..., \n    'map_yaml_path': ...,\n    'share_map': ..., \n    'priority': 1\n  },\n}
+
+FM -> FM: __handle_ikkatsu_parameters(data)
+FM -> FM: Update internal map configurations
+
+note over FM: The FM stores and manages a list of robot configurations, each with its associated map settings. The __handle_ikkatsu_parameters function updates these internal configurations. The maps directory paths are unique for each robot.
+
+== 5. Configure Fleet Manager ==
+FM -> ConfigDB: Update robot_config.json
+note right: Add/update map file paths\nfor multiple robots
+FM -> FM: Configure Fleet Manager
+FM --> U: Confirm process completion
+deactivate FM
+@enduml

--- a/python/demos/grpc_samples/test_multi_map_exporter.py
+++ b/python/demos/grpc_samples/test_multi_map_exporter.py
@@ -1,0 +1,32 @@
+import unittest
+from unittest.mock import patch, MagicMock
+import os
+import subprocess
+from multi_map_exporter import sanitize_filename, check_ssh_connection, create_remote_directory, transfer_files_scp
+
+class TestMultiMapExporter(unittest.TestCase):
+
+    # def test_sanitize_filename(self):
+    #     self.assertEqual(sanitize_filename("test file.png"), "test_file.png")
+    #     self.assertEqual(sanitize_filename("map!@#$%^&*.yaml"), "map_________.yaml")
+
+    @patch('subprocess.run')
+    def test_check_ssh_connection(self, mock_run):
+        mock_run.return_value.returncode = 0
+        self.assertTrue(check_ssh_connection("password"))
+        
+        mock_run.side_effect = subprocess.CalledProcessError(1, "cmd")
+        self.assertFalse(check_ssh_connection("password"))
+
+    @patch('subprocess.run')
+    def test_create_remote_directory(self, mock_run):
+        create_remote_directory("robot_123", "password")
+        mock_run.assert_called_once()
+
+    @patch('subprocess.run')
+    def test_transfer_files_scp(self, mock_run):
+        transfer_files_scp("local_file.png", "robot_123", "/remote/dir/", "password")
+        mock_run.assert_called_once()
+
+if __name__ == '__main__':
+    unittest.main()

--- a/python/demos/grpc_samples/test_multi_map_exporter_local.py
+++ b/python/demos/grpc_samples/test_multi_map_exporter_local.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+"""
+This is a test script for exporting maps from multiple Kachaka robots using gRPC.
+
+Author: Jimmy Majumder
+Date: 2025-02-20
+Copyright: QibiTech Inc.
+
+"""
+
+import sys
+import grpc
+import kachaka_api_pb2
+from kachaka_api_pb2_grpc import KachakaApiStub
+import yaml
+import struct
+import threading
+import re
+import os
+
+# Define the list of gRPC channel addresses for your Kachaka robots
+grpc_channel_addresses = [
+    "192.168.2.77:26400",  # Replace with your robot's address
+    # "192.168.2.78:26400",  # Add more addresses as needed
+    # "192.168.2.79:26400",
+]
+
+def sanitize_filename(filename):
+    """Sanitizes a string to be a safe filename."""
+    # Replace invalid characters with underscores
+    filename = re.sub(r'[^\w\-_\.]', '_', filename)
+    return filename
+
+def get_map_data(grpc_channel_address):
+    try:
+        stub = KachakaApiStub(grpc.insecure_channel(grpc_channel_address))
+
+        # Get robot serial number
+        serial_number_response = stub.GetRobotSerialNumber(kachaka_api_pb2.GetRequest())
+        robot_serial_number = serial_number_response.serial_number
+        print(f"---------- serial number ({grpc_channel_address}): {robot_serial_number} ----------")
+
+        # Create a folder with the robot's serial number
+        folder_name = sanitize_filename(robot_serial_number)
+        os.makedirs(folder_name, exist_ok=True)
+
+        # Get current map ID
+        current_map_id_response = stub.GetCurrentMapId(kachaka_api_pb2.GetRequest())
+        map_id = current_map_id_response.id
+        print(f"---------- map id ({grpc_channel_address}): {map_id} ----------")
+
+        response = stub.GetRobotVersion(kachaka_api_pb2.GetRequest())
+        print(f"---------- robot version ({grpc_channel_address}) ----------")
+        print(response)
+
+        response = stub.GetPngMap(kachaka_api_pb2.GetRequest())
+        print(f"---------- Map ({grpc_channel_address}) ----------")
+        print(response)
+
+        # Extract the map name and sanitize it
+        map_name = sanitize_filename(response.map.name)
+
+        # Construct the filename using only the map_name
+        filename_prefix = f"{map_name}"
+        png_filename = os.path.join(folder_name, f"{filename_prefix}.png")
+        yaml_filename = os.path.join(folder_name, f"{filename_prefix}_metadata.yaml")
+        bin_filename = os.path.join(folder_name, f"{filename_prefix}_metadata.bin")
+
+        # Save the map image data
+        with open(png_filename, "wb") as binary_file:
+            binary_file.write(response.map.data)
+
+        # Extract map metadata
+        map_metadata = {
+            "name": response.map.name,
+            "resolution": response.map.resolution,
+            "width": response.map.width,
+            "height": response.map.height,
+            "origin": {
+                "x": response.map.origin.x,
+                "y": response.map.origin.y,
+                "theta": response.map.origin.theta,
+            },
+        }
+
+        # Print extracted map metadata
+        print(f"Extracted Map Metadata ({grpc_channel_address}):", map_metadata)
+
+        # Save map metadata to YAML file
+        with open(yaml_filename, "w") as yaml_file:
+            yaml.dump(map_metadata, yaml_file, default_flow_style=False)
+
+        # Save metadata (cursor) to binary file
+        cursor_value = response.metadata.cursor
+        with open(bin_filename, "wb") as binary_file:
+            # Pack the sfixed64 value into bytes " '<q' for little-endian sfixed64"
+            binary_file.write(struct.pack("<q", cursor_value))
+
+        # Read metadata (cursor) from binary file
+        with open(bin_filename, "rb") as binary_file:
+            binary_data = binary_file.read(8)
+            cursor_value_read = struct.unpack("<q", binary_data)[0]
+            print(f"Read Cursor Value ({grpc_channel_address}):", cursor_value_read)
+
+    except grpc.RpcError as e:
+        print(f"Error connecting to {grpc_channel_address}: {e}")
+    except Exception as e:
+        print(f"An unexpected error occurred: {e}")  # catch other errors
+
+def main():
+    threads = []
+    for address in grpc_channel_addresses:
+        thread = threading.Thread(target=get_map_data, args=(address,))
+        threads.append(thread)
+        thread.start()
+
+    for thread in threads:
+        thread.join()  # Wait for all threads to complete
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This PR introduces the multi-map exporter feature of "python/demos/grpc_samples" to the Edge PC which is necessary for the Kachaka fleet demo. 


The feature includes:
1. multi_map_exporter.py: Implements the logic for exporting multiple maps.
2. multi_map_exporter_kachaka_fleet.puml: A UML diagram for the Kachaka fleet multi-map exporter.
3. Tests for the feature: test_multi_map_exporter.py and test_multi_map_exporter_local.py.

The changes are designed to enhance the functionality of the existing Kachaka API by enabling the export of multiple maps, which is a key feature for Kachaka fleet management for multiple edge and kachaka control though HATS fleet manager. Thanks!